### PR TITLE
Create generic message await

### DIFF
--- a/internal/websocket/connection.go
+++ b/internal/websocket/connection.go
@@ -1,0 +1,67 @@
+package websocket
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"time"
+)
+
+func AwaitMsg(conn *SyncedWebsocket, msgType MessageType, timeout time.Duration) (Message, error) {
+	ch := make(chan int)
+	closeCh := func() { ch <- 0 }
+
+	var msg Message
+	var err error
+
+	log.Printf("Awaiting %q...\n", msgType)
+
+	go func() {
+		defer closeCh()
+
+		if timeout.Milliseconds() == 0 {
+			return
+		}
+
+		time.Sleep(timeout)
+
+		if msg.Type == msgType || err != nil {
+			return
+		}
+
+		err = errors.New("websocket timed out")
+	}()
+
+	go func() {
+		defer closeCh()
+
+		for {
+			if err = conn.ReadJSON(&msg); err != nil {
+				return
+			}
+
+			// Check for the desired message, ignore other valid messages,
+			// and exit on error or on an invalid message.
+			switch msg.Type {
+			case msgType:
+				return
+			case MessageInfo, MessagePeers, MessageWsOpened, MessageSize:
+				continue
+			case MessageSshCfg, MessageSshHost, MessageSshHostAct, MessageSshSuccess:
+				continue
+			case MessageInput, MessageOutput:
+				continue
+			case MessageError, MessageSshErr, MessageWsError:
+				err = errors.New(string(msg.Type))
+				return
+			default:
+				err = fmt.Errorf("invalid msg received. [%v] %q", msg.Type, msg.Data)
+				return
+			}
+		}
+	}()
+
+	<-ch
+
+	return msg, err
+}

--- a/internal/websocket/hub.go
+++ b/internal/websocket/hub.go
@@ -65,8 +65,7 @@ func (h Hub) AwaitMsg(msgType MessageType, timeout time.Duration) (Message, erro
 
 		time.Sleep(timeout)
 
-		if msg != (Message{}) || err != nil {
-			log.Printf("timeout cancelled: non-empty %q [%v]", msg.Type, err) //// TODO: TEMP
+		if msg.Type == msgType || err != nil {
 			return
 		}
 

--- a/ssh.go
+++ b/ssh.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	ws "github.com/sammy-t/ts-term/internal/websocket"
 	"golang.org/x/crypto/ssh"
@@ -40,8 +41,8 @@ func getHostKeyCallback(conn *ws.SyncedWebsocket, knownHostsPath string) ssh.Hos
 			}
 
 			// Await a response
-			respMsg, respErr := awaitConnectionMsg(conn, 0)
-			if respErr != nil || respMsg.Type != ws.MessageSshHostAct {
+			respMsg, respErr := ws.AwaitMsg(conn, ws.MessageSshHostAct, 1*time.Minute)
+			if respErr != nil {
 				log.Printf("host await msg: %v", respErr)
 				return errors.New("host await msg error")
 			}
@@ -90,8 +91,8 @@ func reattemptSSH(r *http.Request, server *tsnet.Server, conn *ws.SyncedWebsocke
 			return nil, nil, nil, fmt.Errorf("json msg: %w", err)
 		}
 
-		respMsg, err := awaitConnectionMsg(conn, 0)
-		if err != nil || respMsg.Type != ws.MessageSshCfg {
+		respMsg, err := ws.AwaitMsg(conn, ws.MessageSshCfg, 1*time.Minute)
+		if err != nil {
 			if sshErr != nil {
 				log.Printf("await msg: %v", err)
 				return nil, nil, nil, sshErr

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -206,6 +206,7 @@ function connectTsWs(url) {
 		console.log(ev);
 
 		dialogProg.close();
+		dialogErr.close();
 
 		const msg = `Tailscale WebSocket closed. ${ev.reason || ''}\r\n`;
 		term.write((isOnNewline) ? msg : `\r\n${msg}`);


### PR DESCRIPTION
This is suitable for situations when an ongoing listener hub isn't needed.